### PR TITLE
updates references to the Spring Boot service port

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -95,3 +95,18 @@ editor:
   parameters:
     - "base_docker_repository": "sashajo"
 
+---
+kind: "operation"
+client: "atomist"
+editor:
+  name: "atomist-rugs.spring-boot-editors.UpdateServicePort"
+  group: "atomist-rugs"
+  artifact: "spring-boot-editors"
+  version: "0.3.0"
+  origin:
+    repo: "atomist-rugs/spring-boot-editors.git"
+    branch: "3ef0b81b36ddada7a53d54ee9b731665de02a99b"
+    sha: "3ef0b81"
+  parameters:
+    - "service_port": "9090"
+

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -11,6 +11,6 @@ COPY BOOT-INF/classes /opt/build/BOOT-INF/classes
 
 WORKDIR /opt/build/
 
-EXPOSE 8080
+EXPOSE 9090
 
 CMD ["java", "-Xmx1g", "org.springframework.boot.loader.JarLauncher"]

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-server.port=8080
+server.port=9090


### PR DESCRIPTION
Created by Atomist Editor `atomist-rugs.spring-boot-editors.UpdateServicePort`
```
---
kind: "operation"
client: "atomist-bot"
editor:
  name: "atomist-rugs.spring-boot-editors.UpdateServicePort"
  group: "atomist-rugs"
  artifact: "spring-boot-editors"
  version: "0.3.0"
  origin:
    repo: "atomist-rugs/spring-boot-editors.git"
    branch: "3ef0b81b36ddada7a53d54ee9b731665de02a99b"
    sha: "3ef0b81"
  parameters:
    - "service_port": "9090"

```